### PR TITLE
Backport of 2.1.5 features on 1.3.2 ConnId framework

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.connid.bundles.db</groupId>
     <artifactId>db</artifactId>
-    <version>2.1.6-SNAPSHOT</version>
+    <version>2.1.4.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.connid.bundles.db</groupId>
@@ -47,12 +47,12 @@
   <dependencies>
     <dependency>
       <groupId>org.connid</groupId>
-      <artifactId>connid-framework</artifactId>
+      <artifactId>framework</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.connid</groupId>
-      <artifactId>connid-framework-internal</artifactId>
+      <artifactId>framework-internal</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,12 @@
   <parent>
     <artifactId>connid</artifactId>
     <groupId>org.connid</groupId>
-    <version>1.3.3</version>
+    <version>1.3.2</version>
   </parent>
 
   <groupId>org.connid.bundles.db</groupId>
   <artifactId>db</artifactId>
-  <version>2.1.6-SNAPSHOT</version>
+  <version>2.1.4.1-SNAPSHOT</version>
 
   <name>ConnId Bundles: DB</name>
 
@@ -81,7 +81,7 @@
   </mailingLists>
 
   <properties>
-    <base.version>1.3.3</base.version>
+    <base.version>1.3.2</base.version>
   </properties>
 
   <dependencyManagement>
@@ -89,28 +89,28 @@
             
       <dependency>
         <groupId>org.connid</groupId>
-        <artifactId>connid-framework</artifactId>
+        <artifactId>framework</artifactId>
         <version>${base.version}</version>
         <scope>compile</scope>
       </dependency>
 
       <dependency>
         <groupId>org.connid</groupId>
-        <artifactId>connid-framework-internal</artifactId>
+        <artifactId>framework-internal</artifactId>
         <version>${base.version}</version>
         <scope>runtime</scope>
       </dependency>
 
       <dependency>
         <groupId>org.connid</groupId>
-        <artifactId>connid-test-common</artifactId>
+        <artifactId>test-common</artifactId>
         <version>${base.version}</version>
         <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>org.connid</groupId>
-        <artifactId>connid-test-contract</artifactId>
+        <artifactId>test-contract</artifactId>
         <version>${base.version}</version>
         <scope>test</scope>
       </dependency>

--- a/table/pom.xml
+++ b/table/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.connid.bundles.db</groupId>
     <artifactId>db</artifactId>
-    <version>2.1.6-SNAPSHOT</version>
+    <version>2.1.4.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.connid.bundles.db</groupId>
@@ -47,12 +47,12 @@
   <dependencies>
     <dependency>
       <groupId>org.connid</groupId>
-      <artifactId>connid-framework</artifactId>
+      <artifactId>framework</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.connid</groupId>
-      <artifactId>connid-framework-internal</artifactId>
+      <artifactId>framework-internal</artifactId>
     </dependency>
 
     <dependency>
@@ -69,13 +69,13 @@
 
     <dependency>
       <groupId>org.connid</groupId>
-      <artifactId>connid-test-common</artifactId>
+      <artifactId>test-common</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.connid</groupId>
-      <artifactId>connid-test-contract</artifactId>
+      <artifactId>test-contract</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Hi,

I followed the steps you suggested [1] and I get a working "mvn clean package". (At the moment I didn't had time to test it on RDBMS like MySQL or Oracle).

Due to framework refatcory between 1.3.2 and 1.3.3 I need to reverted all connd framework dependecies from connid-framework\* to framework*. I hope don't forget anything :P

Regards,
Denis

[1] http://syncope-user.1051894.n5.nabble.com/Framework-and-connectors-dependecies-tp5706961p5706962.html
